### PR TITLE
Support activesupport v7

### DIFF
--- a/turnip_formatter.gemspec
+++ b/turnip_formatter.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'rspec', [">=3.3", "<4.0"]
 
   # For ruby >= 2.1
-  spec.add_dependency 'activesupport', '>= 4.2.7', '< 7.0'
+  spec.add_dependency 'activesupport', '>= 4.2.7', '< 8.0'
 
   spec.add_development_dependency 'test-unit'
   spec.add_development_dependency 'test-unit-rr'


### PR DESCRIPTION
activesupport 7 has String#{demodulize,underscore} as same as 6. Ref: https://github.com/gongo/turnip_formatter/pull/102

- 7.0.6
  - [String#demodulize](https://github.com/rails/rails/blob/v7.0.6/activesupport/lib/active_support/core_ext/string/inflections.rb#L162) / [ActiveSupport::ActiveSupport::demodulize](https://github.com/rails/rails/blob/v7.0.6/activesupport/lib/active_support/inflector/methods.rb#L226)
  - [String#underscore](https://github.com/rails/rails/blob/v7.0.6/activesupport/lib/active_support/core_ext/string/inflections.rb#L139) / [ActiveSupport::ActiveSupport::underscore](https://github.com/rails/rails/blob/v7.0.6/activesupport/lib/active_support/inflector/methods.rb#L96)

- 6.1.7.4
  - [String#demodulize](https://github.com/rails/rails/blob/v6.1.7.4/activesupport/lib/active_support/core_ext/string/inflections.rb#L166) / [ActiveSupport::ActiveSupport::demodulize](https://github.com/rails/rails/blob/v6.1.7.4/activesupport/lib/active_support/inflector/methods.rb#L220)
  - [String#underscore](https://github.com/rails/rails/blob/v6.1.7.4/activesupport/lib/active_support/core_ext/string/inflections.rb#L143) / [ActiveSupport::ActiveSupport::underscore](https://github.com/rails/rails/blob/v6.1.7.4/activesupport/lib/active_support/inflector/methods.rb#L92)


Travis is not running now, but I confirmed test passed on local. So, it seems ok.
```
$ bundle exec rake test
/Users/me/.rbenv/versions/3.2.2/bin/ruby -I"lib:test" /Users/me/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/rake-13.0.6/lib/rake/rake_test_loader.rb "test/turnip_formatter/renderer/html/test_data_table.rb" "test/turnip_formatter/renderer/html/test_doc_string.rb" "test/turnip_formatter/renderer/html/test_index.rb" "test/turnip_formatter/renderer/html/test_runtime_error.rb" "test/turnip_formatter/renderer/html/test_statistics_feature.rb" "test/turnip_formatter/renderer/html/test_statistics_speed.rb" "test/turnip_formatter/renderer/html/test_statistics_tag.rb" "test/turnip_formatter/renderer/html/test_step.rb" "test/turnip_formatter/renderer/test_html.rb" "test/turnip_formatter/resource/scenario/test_failure.rb" "test/turnip_formatter/resource/scenario/test_pass.rb" "test/turnip_formatter/resource/scenario/test_pending.rb" "test/turnip_formatter/step_template/test_base.rb" "test/turnip_formatter/step_template/test_exception.rb" "test/turnip_formatter/step_template/test_source.rb" 
Loaded suite /Users/me/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/rake-13.0.6/lib/rake/rake_test_loader
Started
Finished in 0.127823 seconds.
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
51 tests, 70 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
398.99 tests/s, 547.63 assertions/s
```